### PR TITLE
feat: add syncer interface for defining upload/download data between cloud storage and local disk

### DIFF
--- a/cmd/grit-agent/app/app.go
+++ b/cmd/grit-agent/app/app.go
@@ -20,6 +20,7 @@ import (
 	"github.com/kaito-project/grit/pkg/apis/v1alpha1"
 	"github.com/kaito-project/grit/pkg/gritagent/checkpoint"
 	"github.com/kaito-project/grit/pkg/gritagent/restore"
+	"github.com/kaito-project/grit/pkg/gritagent/syncer/file"
 	"github.com/kaito-project/grit/pkg/injections"
 )
 
@@ -56,6 +57,9 @@ func Run(opts *options.GritAgentOptions) error {
 	//logging
 	logger := klog.FromContext(ctx)
 	log.SetLogger(logger)
+
+	// init checkpointed data syncer
+	opts.Syncer = file.NewFileSyncer()
 
 	var handler func(context.Context, *options.GritAgentOptions) error
 

--- a/cmd/grit-agent/app/options/options.go
+++ b/cmd/grit-agent/app/options/options.go
@@ -7,6 +7,8 @@ import (
 	"os"
 
 	"github.com/spf13/pflag"
+
+	"github.com/kaito-project/grit/pkg/gritagent/syncer"
 )
 
 type GritAgentOptions struct {
@@ -16,6 +18,7 @@ type GritAgentOptions struct {
 	Action          string
 	SrcDir          string
 	DstDir          string
+	Syncer          syncer.Syncer
 
 	RuntimeCheckpointOptions
 }

--- a/pkg/gritagent/checkpoint/checkpoint.go
+++ b/pkg/gritagent/checkpoint/checkpoint.go
@@ -7,7 +7,6 @@ import (
 	"context"
 
 	"github.com/kaito-project/grit/cmd/grit-agent/app/options"
-	"github.com/kaito-project/grit/pkg/gritagent/copy"
 )
 
 func RunCheckpoint(ctx context.Context, opts *options.GritAgentOptions) error {
@@ -17,5 +16,5 @@ func RunCheckpoint(ctx context.Context, opts *options.GritAgentOptions) error {
 	}
 
 	// transfer checkpointed data to cloud storage
-	return copy.TransferData(ctx, opts.SrcDir, opts.DstDir)
+	return opts.Syncer.Sync(ctx, opts.SrcDir, opts.DstDir)
 }

--- a/pkg/gritagent/restore/restore.go
+++ b/pkg/gritagent/restore/restore.go
@@ -7,15 +7,15 @@ import (
 	"context"
 
 	"github.com/kaito-project/grit/cmd/grit-agent/app/options"
-	"github.com/kaito-project/grit/pkg/gritagent/copy"
+	"github.com/kaito-project/grit/pkg/gritagent/util"
 	"github.com/kaito-project/grit/pkg/metadata"
 )
 
 func RunRestore(ctx context.Context, opts *options.GritAgentOptions) error {
 	// download checkpointed data from cloud storage
-	if err := copy.TransferData(ctx, opts.SrcDir, opts.DstDir); err != nil {
+	if err := opts.Syncer.Sync(ctx, opts.SrcDir, opts.DstDir); err != nil {
 		return err
 	}
 
-	return copy.CreateSentinelFile(opts.DstDir, metadata.DownloadSentinelFile)
+	return util.CreateSentinelFile(opts.DstDir, metadata.DownloadSentinelFile)
 }

--- a/pkg/gritagent/syncer/file/syncer.go
+++ b/pkg/gritagent/syncer/file/syncer.go
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-package copy
+package file
 
 import (
 	"context"
@@ -12,9 +12,21 @@ import (
 
 	"go.uber.org/multierr"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/kaito-project/grit/pkg/gritagent/syncer"
 )
 
-func TransferData(ctx context.Context, srcDir, dstDir string) error {
+type fileSyncerImpl struct{}
+
+func NewFileSyncer() syncer.Syncer {
+	return &fileSyncerImpl{}
+}
+
+func (sfi *fileSyncerImpl) Name() string {
+	return "FileSyncer"
+}
+
+func (sfi *fileSyncerImpl) Sync(ctx context.Context, srcDir, dstDir string) error {
 	var wg sync.WaitGroup
 	errs := make([]error, 20)
 	workerChan := make(chan struct{}, 10)
@@ -87,16 +99,4 @@ func copyFile(srcFile, dstFile string) error {
 	}
 
 	return os.Chmod(dstFile, info.Mode())
-}
-
-func CreateSentinelFile(dir, fileName string) error {
-	filePath := filepath.Join(dir, fileName)
-	f, err := os.Create(filePath)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-
-	_, err = f.WriteString("Transfer Completed\n")
-	return err
 }

--- a/pkg/gritagent/syncer/interface.go
+++ b/pkg/gritagent/syncer/interface.go
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+package syncer
+
+import (
+	"context"
+)
+
+// Syncer defines the ability to transfer files between cloud storage and local disk.
+type Syncer interface {
+	Name() string
+	// Sync copy all files from srcDir to dstDir, while keeping the file directory structure unchanged.
+	Sync(ctx context.Context, srcDir, dstDir string) error
+}

--- a/pkg/gritagent/util/util.go
+++ b/pkg/gritagent/util/util.go
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+package util
+
+import (
+	"os"
+	"path/filepath"
+)
+
+func CreateSentinelFile(dir, fileName string) error {
+	filePath := filepath.Join(dir, fileName)
+	f, err := os.Create(filePath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	_, err = f.WriteString("Transfer Completed\n")
+	return err
+}


### PR DESCRIPTION
add a syncer interface for defining upload/download data between cloud storage and local disk. then we will implement other copy solutions for faster data transfer speed.